### PR TITLE
Confidence in dose model

### DIFF
--- a/examples/IC50/test_paccmann_dose.py
+++ b/examples/IC50/test_paccmann_dose.py
@@ -185,13 +185,17 @@ def main(
         test_loss = 0
         predictions = []
         gene_attentions = []
+        epistemic_confs = []
+        aleatoric_confs = []
         labels = []
         for ind, (smiles, gep, dose, y) in enumerate(test_loader):
             y_hat, pred_dict = model(
-                torch.squeeze(smiles.to(device)), gep.to(device), dose.to(device)
+                torch.squeeze(smiles.to(device)), gep.to(device), dose.to(device), confidence = True
             )
             predictions.append(y_hat)
             gene_attentions.append(pred_dict['gene_attention'])
+            epistemic_confs.append(pred_dict['epistemic_confidence'])
+            aleatoric_confs.append(pred_dict['aleatoric_confidence'])
             labels.append(y)
             loss = model.loss(y_hat, y.to(device))
             test_loss += loss.item()
@@ -200,6 +204,8 @@ def main(
     predictions = np.array([p.cpu().numpy() for preds in predictions for p in preds]).ravel()
     gene_attentions = np.array([a.cpu().numpy() for atts in gene_attentions for a in atts])
     labels = np.array([l.cpu().numpy() for label in labels for l in label]).ravel()
+    epistemic_confs = np.array([c.cpu().numpy() for conf in epistemic_confs for c in conf]).ravel()
+    aleatoric_confs = np.array([c.cpu().numpy() for conf in aleatoric_confs for c in conf]).ravel()
 
     # torch 1.0.1 version
     #predictions = np.array([pred_tensor.cpu().numpy() for pred_tensor in predictions])).ravel()
@@ -219,6 +225,8 @@ def main(
 
     np.save(predictions_filepath+'.npy', predictions)
     np.save(predictions_filepath+'_gene_attention.npy', gene_attentions)
+    np.save(predictions_filepath+'_epistemic_confidence.npy', epistemic_confs)
+    np.save(predictions_filepath+'_aleatoric_confidence.npy', aleatoric_confs)
 
 if __name__ == '__main__':
     # parse arguments

--- a/paccmann_predictor/models/paccmann_v2.py
+++ b/paccmann_predictor/models/paccmann_v2.py
@@ -1,16 +1,22 @@
+import logging
+import sys
 from collections import OrderedDict
 
+import pytoda
 import torch
 import torch.nn as nn
-import pytoda
 from pytoda.smiles.transforms import AugmentTensor
 
 from ..utils.hyperparams import ACTIVATION_FN_FACTORY, LOSS_FN_FACTORY
 from ..utils.interpret import monte_carlo_dropout, test_time_augmentation
 from ..utils.layers import (
-    convolutional_layer, dense_layer, ContextAttentionLayer
+    ContextAttentionLayer, convolutional_layer, dense_layer
 )
 from ..utils.utils import get_device, get_log_molar
+
+# setup logging
+logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
+logger = logging.getLogger(__name__)
 
 
 class PaccMannV2(nn.Module):
@@ -302,13 +308,13 @@ class PaccMannV2(nn.Module):
 
             if confidence:
                 augmenter = AugmentTensor(self.smiles_language)
-                epistemic_conf = monte_carlo_dropout(
+                epi_conf, epi_pred = monte_carlo_dropout(
                     self,
                     regime='tensors',
                     tensors=(smiles, gep),
                     repetitions=5
                 )
-                aleatoric_conf = test_time_augmentation(
+                ale_conf, ale_pred = test_time_augmentation(
                     self,
                     regime='tensors',
                     tensors=(smiles, gep),
@@ -318,9 +324,14 @@ class PaccMannV2(nn.Module):
                 )
 
                 prediction_dict.update({
-                    'epistemic_confidence': epistemic_conf,
-                    'aleatoric_confidence': aleatoric_conf
+                    'epistemic_confidence': epi_conf,
+                    'epistemic_predictions': epi_pred,
+                    'aleatoric_confidence': ale_conf,
+                    'aleatoric_predictions': ale_pred
                 })  # yapf: disable
+
+        elif confidence:
+            logger.info('Using confidence in training mode is not supported.')
 
         return predictions, prediction_dict
 

--- a/paccmann_predictor/utils/layers.py
+++ b/paccmann_predictor/utils/layers.py
@@ -220,10 +220,9 @@ class ContextAttentionLayer(nn.Module):
         Forward pass through a context attention layer
         Arguments:
             reference (torch.Tensor): This is the reference input on which
-                attention is computed.
-                Shape: batch_size x ref_seq_length x ref_hidden_size
+                attention is computed. Shape: bs x ref_seq_length x ref_hidden_size
             context (torch.Tensor): This is the context used for attention.
-                Shape: batch_size x context_seq_length x context_hidden_size
+                Shape: bs x context_seq_length x context_hidden_size
             average_seq (bool): Whether the filtered attention is averaged over the
                 sequence length.
                 NOTE: This is recommended to be True, however if the ref_hidden_size
@@ -232,8 +231,8 @@ class ContextAttentionLayer(nn.Module):
         Returns:
             (output, attention_weights):  A tuple of two Tensors, first one
                 containing the reference filtered by attention (shape:
-                batch_size x ref_hidden_size) and the second one the
-                attention weights (batch_size x ref_seq_length).
+                bs x ref_hidden_size) and the second one the
+                attention weights (bs x ref_seq_length).
                 NOTE: If average_seq is False, the output is: bs x ref_seq_length
         """
         assert len(reference.shape) == 3, 'Reference tensor needs to be 3D'


### PR DESCRIPTION
- Streamlined confidence computation across all implemented models and added some logic
- Added confidence computation to the dose model (set model in `eval()` mode and pass `confidence=True` to the forward function)

@eovchinn the prediction dict should contain keys now for aleatoric and epistemic uncertainty and confidence and predictions respectively. The predictions might even be better since the original ones since they stem from some implicit model ensemble. The confidences should be interpreted in relative terms, they vary between 1 (high confidence) and 0 (low confidence) but in general, values below <0.5 will be extremely rare (I guess).